### PR TITLE
docs: longer description

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yet_another_json_isolate
-description: Create isolates to parse JSON
+description: Package to simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
 version: 1.0.0
 homepage: https://github.com/supabase-community/json-isolate-dart
 


### PR DESCRIPTION
I'm making the description longer to get 140/140 points on pub.dev https://pub.dev/packages/yet_another_json_isolate/score