### PR TITLE
fix: rename `init` to `initialize` on web and release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- fix: rename `init` to `initialize` on web
+
 ## 1.0.0
 
 - Initial version.

--- a/lib/src/_isolates_web.dart
+++ b/lib/src/_isolates_web.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 class YAJsonIsolate {
-  Future<void> init() async {}
+  Future<void> initialize() async {}
 
   Future<void> dispose() async {}
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yet_another_json_isolate
 description: Create isolates to parse JSON
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/supabase-community/json-isolate-dart
 
 environment:


### PR DESCRIPTION
## What kind of change does this PR introduce?

flutter_web for this package is still using `init` instead of `initialize`. This PR fixes it