### PR TITLE
fix: lower async package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- fix: lower async package version
+
 ## 1.0.1
 
 - fix: rename `init` to `initialize` on web

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: yet_another_json_isolate
 description: Package to simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/supabase-community/json-isolate-dart
 
 environment:
   sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
-  async: ^2.9.0
+  async: ^2.8.0
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
async 2.9.0 isn't compatible with flutter_test in flutter 2.8.0

https://github.com/supabase/supabase-flutter/actions/runs/3894236252/jobs/6647942169#step:5:41