### PR TITLE
fix: correctly check for web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- fix: correctly check for web platform
+
 ## 1.0.2
 
 - fix: lower async package version

--- a/lib/yet_another_json_isolate.dart
+++ b/lib/yet_another_json_isolate.dart
@@ -1,3 +1,3 @@
 library yet_another_json_isolate;
 
-export 'src/_isolates_io.dart' if (dart.library.html) 'src/_isolates_web.dart';
+export 'src/_isolates_io.dart' if (dart.library.js) 'src/_isolates_web.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yet_another_json_isolate
 description: Package to simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/supabase-community/json-isolate-dart
 
 environment:


### PR DESCRIPTION
I was a bit suprised if the YAJsonIsolate overriding [here](https://supabase.com/docs/guides/functions/dart-edge#override-the-json-isolate) is really necessary. In a short test switching to `js` instead `html` seems to work and makes sense, since the dart edge doesn't have access to html, but js.